### PR TITLE
Remove libvpx1 from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ addons:
     - libpng-dev
     - libx264-dev
     - libass-dev
-    - libvpx1
     - libvpx-dev
     - libwebp-dev
     - webp

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
     - python-scipy
     - cython
 install:
-  - wget http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
+  - wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
     -O /tmp/ffmpeg-release.tar.xz
   - mkdir /tmp/ffmpeg-release
   - tar -C /tmp/ffmpeg-release --strip 1 -xvf /tmp/ffmpeg-release.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - UNIT_TEST=1
 addons:
   apt:
+    sources:
+    - trusty-media
     packages:
     - libcurl4-openssl-dev
     - python-numpy
@@ -35,13 +37,8 @@ addons:
     - python-numpy
     - python-scipy
     - cython
+    - ffmpeg
 install:
-  - wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
-    -O /tmp/ffmpeg-release.tar.xz
-  - mkdir /tmp/ffmpeg-release
-  - tar -C /tmp/ffmpeg-release --strip 1 -xvf /tmp/ffmpeg-release.tar.xz
-  - export PATH=/tmp/ffmpeg-release:$PATH
-  - ffmpeg -version
   - pip install --upgrade pip
   - make setup
   - pip install coveralls


### PR DESCRIPTION
This library was disallowed by travis (or ubuntu xenial) itself in the old builds.